### PR TITLE
Make some kafka errors retriable.

### DIFF
--- a/kafka/errors.py
+++ b/kafka/errors.py
@@ -242,6 +242,8 @@ class NotEnoughReplicasError(BrokerResponseError):
     description = ('Returned from a produce request when the number of in-sync'
                    ' replicas is lower than the configured minimum and'
                    ' requiredAcks is -1.')
+    retriable = True
+    invalid_metadata = True
 
 
 class NotEnoughReplicasAfterAppendError(BrokerResponseError):
@@ -250,6 +252,8 @@ class NotEnoughReplicasAfterAppendError(BrokerResponseError):
     description = ('Returned from a produce request when the message was'
                    ' written to the log, but with fewer in-sync replicas than'
                    ' required.')
+    retriable = True
+    invalid_metadata = True
 
 
 class InvalidRequiredAcksError(BrokerResponseError):


### PR DESCRIPTION
Based on https://kafka.apache.org/protocol#protocol_error_codes, kafka
errors NOT_ENOUGH_REPLICAS and NOT_ENOUGH_REPLICAS_AFTER_APPEND should
be retriable.